### PR TITLE
Add roles to users

### DIFF
--- a/db/migrate/20250218220321_add_role_to_starlink_users.rb
+++ b/db/migrate/20250218220321_add_role_to_starlink_users.rb
@@ -1,0 +1,9 @@
+class AddRoleToStarlinkUsers < ActiveRecord::Migration[7.1]
+  def up
+    add_column :starlink_users, :role, :string, default: "user", null: false
+  end
+
+  def down
+    remove_column :starlink_users, :role
+  end
+end


### PR DESCRIPTION
This PR introduces a new role column to the starlink_users table. The column will help differentiate user roles (e.g., admin, user) within the system.

**Changes Made**

- Added a role column to the starlink_users table (string, default: "user", null: false).
- Implemented up and down methods for migration reversibility.
